### PR TITLE
Fixing linear assignment to fix deprecation error sklearn

### DIFF
--- a/deep_sort/sort/linear_assignment.py
+++ b/deep_sort/sort/linear_assignment.py
@@ -1,7 +1,8 @@
 # vim: expandtab:ts=4:sw=4
 from __future__ import absolute_import
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+# from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment as linear_assignment
 from . import kalman_filter
 
 
@@ -55,16 +56,17 @@ def min_cost_matching(
     cost_matrix = distance_metric(
         tracks, detections, track_indices, detection_indices)
     cost_matrix[cost_matrix > max_distance] = max_distance + 1e-5
-    indices = linear_assignment(cost_matrix)
+
+    row_indices, col_indices = linear_assignment(cost_matrix)
 
     matches, unmatched_tracks, unmatched_detections = [], [], []
     for col, detection_idx in enumerate(detection_indices):
-        if col not in indices[:, 1]:
+        if col not in col_indices:
             unmatched_detections.append(detection_idx)
     for row, track_idx in enumerate(track_indices):
-        if row not in indices[:, 0]:
+        if row not in row_indices:
             unmatched_tracks.append(track_idx)
-    for row, col in indices:
+    for row, col in zip(row_indices, col_indices):
         track_idx = track_indices[row]
         detection_idx = detection_indices[col]
         if cost_matrix[row, col] > max_distance:


### PR DESCRIPTION
Thank you for the amazing repository and sharing your trained models.

`sklearn.utils.linear_assignment_` is deprecated as of 0.21 in favor of `scipy.optimize.linear_sum_assignment`

This is used in `deep_sort/sort/linear_assignment.py`

This PR `scipy.optimize` and makes minor changes to remove the deprecation error.