### PR TITLE
resolved bug where yolov3_deepsort_eval cannot get logger

### DIFF
--- a/yolov3_deepsort_eval.py
+++ b/yolov3_deepsort_eval.py
@@ -4,7 +4,7 @@ import logging
 import argparse
 from pathlib import Path
 
-from utils.log import logger
+from utils.log import get_logger
 from yolov3_deepsort import VideoTracker
 from utils.parser import get_config
 


### PR DESCRIPTION
`yolov3_deepsort_eval.py` import statement for function in `utils.log.py` was incorrect. Updated import to the correct function name.