### PR TITLE
support fast-reid

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/fast-reid"]
+	path = thirdparty/fast-reid
+	url = https://github.com/JDAI-CV/fast-reid.git

--- a/README.md
+++ b/README.md
@@ -79,30 +79,48 @@ cd ../../..
 Notice:
 If compiling failed, the simplist way is to **Upgrade your pytorch >= 1.1 and torchvision >= 0.3" and you can avoid the troublesome compiling problems which are most likely caused by either `gcc version too low` or `libraries missing`.
 
-5. Run demo
+5. (Optional) Prepare [fast-reid](https://github.com/JDAI-CV/fast-reid)
+
+This library supports bagtricks, AGW and other mainstream ReID methods through providing an fast-reid adapter.
+
+Run
+
 ```
-usage: python yolov3_deepsort.py VIDEO_PATH
-                                [--help]
-                                [--frame_interval FRAME_INTERVAL]
-                                [--config_detection CONFIG_DETECTION]
-                                [--config_deepsort CONFIG_DEEPSORT]
-                                [--display]
-                                [--display_width DISPLAY_WIDTH]
-                                [--display_height DISPLAY_HEIGHT]
-                                [--save_path SAVE_PATH]          
-                                [--cpu]          
+git submodule update --init --recursive
+```
+
+to prepare our bundled fast-reid, then follow instructions in its README to install it.
+
+Please refer to `configs/fastreid.yaml` for a sample of using fast-reid. See [Model Zoo](https://github.com/JDAI-CV/fast-reid/blob/master/docs/MODEL_ZOO.md) for available methods and trained models.
+
+
+6. Run demo
+```
+usage: deepsort.py [-h]
+                   [--fastreid]
+                   [--config_fastreid CONFIG_FASTREID]
+                   [--config_detection CONFIG_DETECTION]
+                   [--config_deepsort CONFIG_DEEPSORT] [--display]
+                   [--frame_interval FRAME_INTERVAL]
+                   [--display_width DISPLAY_WIDTH]
+                   [--display_height DISPLAY_HEIGHT] [--save_path SAVE_PATH]
+                   [--cpu] [--camera CAM]
+                   VIDEO_PATH         
 
 # yolov3 + deepsort
-python yolov3_deepsort.py [VIDEO_PATH]
+python deepsort.py [VIDEO_PATH]
 
 # yolov3_tiny + deepsort
-python yolov3_deepsort.py [VIDEO_PATH] --config_detection ./configs/yolov3_tiny.yaml
+python deepsort.py [VIDEO_PATH] --config_detection ./configs/yolov3_tiny.yaml
 
 # yolov3 + deepsort on webcam
-python3 yolov3_deepsort.py /dev/video0 --camera 0
+python3 deepsort.py /dev/video0 --camera 0
 
 # yolov3_tiny + deepsort on webcam
-python3 yolov3_deepsort.py /dev/video0 --config_detection ./configs/yolov3_tiny.yaml --camera 0
+python3 deepsort.py /dev/video0 --config_detection ./configs/yolov3_tiny.yaml --camera 0
+
+# fast-reid + deepsort
+python deepsort.py [VIDEO_PATH] --fastreid [--config_fastreid ./configs/fastreid.yaml]
 ```
 Use `--display` to enable display.  
 Results will be saved to `./output/results.avi` and `./output/results.txt`.

--- a/configs/fastreid.yaml
+++ b/configs/fastreid.yaml
@@ -1,0 +1,3 @@
+FASTREID:
+  CFG: "thirdparty/fast-reid/configs/Market1501/bagtricks_R50.yml"
+  CHECKPOINT: "deep_sort/deep/checkpoint/market_bot_R50.pth"

--- a/deep_sort/__init__.py
+++ b/deep_sort/__init__.py
@@ -5,7 +5,14 @@ __all__ = ['DeepSort', 'build_tracker']
 
 
 def build_tracker(cfg, use_cuda):
-    return DeepSort(cfg.DEEPSORT.REID_CKPT, 
+    if cfg.USE_FASTREID:
+        return DeepSort(model_path=cfg.FASTREID.CHECKPOINT, model_config=cfg.FASTREID.CFG, 
+                max_dist=cfg.DEEPSORT.MAX_DIST, min_confidence=cfg.DEEPSORT.MIN_CONFIDENCE, 
+                nms_max_overlap=cfg.DEEPSORT.NMS_MAX_OVERLAP, max_iou_distance=cfg.DEEPSORT.MAX_IOU_DISTANCE, 
+                max_age=cfg.DEEPSORT.MAX_AGE, n_init=cfg.DEEPSORT.N_INIT, nn_budget=cfg.DEEPSORT.NN_BUDGET, use_cuda=use_cuda)
+
+    else:
+        return DeepSort(model_path=cfg.DEEPSORT.REID_CKPT, 
                 max_dist=cfg.DEEPSORT.MAX_DIST, min_confidence=cfg.DEEPSORT.MIN_CONFIDENCE, 
                 nms_max_overlap=cfg.DEEPSORT.NMS_MAX_OVERLAP, max_iou_distance=cfg.DEEPSORT.MAX_IOU_DISTANCE, 
                 max_age=cfg.DEEPSORT.MAX_AGE, n_init=cfg.DEEPSORT.N_INIT, nn_budget=cfg.DEEPSORT.NN_BUDGET, use_cuda=use_cuda)

--- a/deep_sort/deep/feature_extractor.py
+++ b/deep_sort/deep/feature_extractor.py
@@ -5,6 +5,9 @@ import cv2
 import logging
 
 from .model import Net
+from fastreid.config import get_cfg
+from fastreid.engine import DefaultTrainer
+from fastreid.utils.checkpoint import Checkpointer
 
 class Extractor(object):
     def __init__(self, model_path, use_cuda=True):
@@ -45,6 +48,43 @@ class Extractor(object):
             im_batch = im_batch.to(self.device)
             features = self.net(im_batch)
         return features.cpu().numpy()
+
+class FastReIDExtractor(object):
+    def __init__(self, model_config, model_path, use_cuda=True):
+        cfg = get_cfg()
+        cfg.merge_from_file(model_config)
+        cfg.MODEL.BACKBONE.PRETRAIN = False
+        self.net = DefaultTrainer.build_model(cfg)
+        self.device = "cuda" if torch.cuda.is_available() and use_cuda else "cpu"
+
+        Checkpointer(self.net).load(model_path)
+        logger = logging.getLogger("root.tracker")
+        logger.info("Loading weights from {}... Done!".format(model_path))
+        self.net.to(self.device)
+        self.net.eval()
+        height, width = cfg.INPUT.SIZE_TEST
+        self.size = (width, height)
+        self.norm = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ])
+
+    
+    def _preprocess(self, im_crops):
+        def _resize(im, size):
+            return cv2.resize(im.astype(np.float32)/255., size)
+
+        im_batch = torch.cat([self.norm(_resize(im, self.size)).unsqueeze(0) for im in im_crops], dim=0).float()
+        return im_batch
+
+
+    def __call__(self, im_crops):
+        im_batch = self._preprocess(im_crops)
+        with torch.no_grad():
+            im_batch = im_batch.to(self.device)
+            features = self.net(im_batch)
+        return features.cpu().numpy()
+
 
 
 if __name__ == '__main__':

--- a/deep_sort/deep_sort.py
+++ b/deep_sort/deep_sort.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from .deep.feature_extractor import Extractor
+from .deep.feature_extractor import Extractor, FastReIDExtractor
 from .sort.nn_matching import NearestNeighborDistanceMetric
 from .sort.preprocessing import non_max_suppression
 from .sort.detection import Detection
@@ -12,11 +12,14 @@ __all__ = ['DeepSort']
 
 
 class DeepSort(object):
-    def __init__(self, model_path, max_dist=0.2, min_confidence=0.3, nms_max_overlap=1.0, max_iou_distance=0.7, max_age=70, n_init=3, nn_budget=100, use_cuda=True):
+    def __init__(self, model_path, model_config=None, max_dist=0.2, min_confidence=0.3, nms_max_overlap=1.0, max_iou_distance=0.7, max_age=70, n_init=3, nn_budget=100, use_cuda=True):
         self.min_confidence = min_confidence
         self.nms_max_overlap = nms_max_overlap
 
-        self.extractor = Extractor(model_path, use_cuda=use_cuda)
+        if model_config is None:
+            self.extractor = Extractor(model_path, use_cuda=use_cuda)
+        else:
+            self.extractor = FastReIDExtractor(model_config, model_path, use_cuda=use_cuda)
 
         max_cosine_distance = max_dist
         nn_budget = 100

--- a/deepsort.py
+++ b/deepsort.py
@@ -5,6 +5,10 @@ import argparse
 import torch
 import warnings
 import numpy as np
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'thirdparty/fast-reid'))
+
 
 from detector import build_detector
 from deep_sort import build_tracker
@@ -12,6 +16,7 @@ from utils.draw import draw_boxes
 from utils.parser import get_config
 from utils.log import get_logger
 from utils.io import write_results
+
 
 
 class VideoTracker(object):
@@ -132,6 +137,8 @@ def parse_args():
     parser.add_argument("VIDEO_PATH", type=str)
     parser.add_argument("--config_detection", type=str, default="./configs/yolov3.yaml")
     parser.add_argument("--config_deepsort", type=str, default="./configs/deep_sort.yaml")
+    parser.add_argument("--config_fastreid", type=str, default="./configs/fastreid.yaml")
+    parser.add_argument("--fastreid", action="store_true")
     # parser.add_argument("--ignore_display", dest="display", action="store_false", default=True)
     parser.add_argument("--display", action="store_true")
     parser.add_argument("--frame_interval", type=int, default=1)
@@ -148,6 +155,11 @@ if __name__ == "__main__":
     cfg = get_config()
     cfg.merge_from_file(args.config_detection)
     cfg.merge_from_file(args.config_deepsort)
+    if args.fastreid:
+        cfg.merge_from_file(args.config_fastreid)
+        cfg.USE_FASTREID = True
+    else:
+        cfg.USE_FASTREID = False
 
     with VideoTracker(cfg, args, video_path=args.VIDEO_PATH) as vdo_trk:
         vdo_trk.run()


### PR DESCRIPTION
引入[fast-reid](https://github.com/JDAI-CV/fast-reid)实现ReID model可选择，包括bagtricks, AGW等多种主流模型结构。保留默认使用原有的ReID model。

解决 #131 