### PR TITLE
Security Fix for Arbitrary Code Execution - huntr.dev

### DIFF
--- a/utils/parser.py
+++ b/utils/parser.py
@@ -13,14 +13,14 @@ class YamlParser(edict):
         if config_file is not None:
             assert(os.path.isfile(config_file))
             with open(config_file, 'r') as fo:
-                cfg_dict.update(yaml.load(fo.read()))
+                cfg_dict.update(yaml.safe_load(fo.read()))
 
         super(YamlParser, self).__init__(cfg_dict)
 
     
     def merge_from_file(self, config_file):
         with open(config_file, 'r') as fo:
-            self.update(yaml.load(fo.read()))
+            self.update(yaml.safe_load(fo.read()))
 
     
     def merge_from_dict(self, config_dict):


### PR DESCRIPTION
https://huntr.dev/users/Anon-Artist has fixed the Arbitrary Code Execution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/deep_sort_pytorch/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/other/deep_sort_pytorch/1/README.md

### User Comments:

### 📊 Metadata *
Arbitrary code exec vulnerability 

#### Bounty URL:  https://www.huntr.dev/bounties/1-other-deep_sort_pytorch

### ⚙️ Description *

Arbitrary Code Excecution in deepsort built on pytorch. MOT tracking using deepsort and yolov3 with pytorch.

### 💻 Technical Description *

This package was vulnerable to Arbitrary code execution due to a use of a known vulnerable function load() in yaml. All the scripts importing utils/parser.py is exploitable.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```import os

os.system('https://github.com/ZQPei/deep_sort_pytorch.git')
os.chdir('deep_sort_pytorch/configs/')
os.system('pip install -r ../requirements.txt')
os.system('rm deep_sort*')
exploit = """DEEPSORT:
  REID_CKPT: "./deep_sort/deep/checkpoint/ckpt.t7"
  Exploit: !!python/object/new:type
    args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
    listitems: "__import__('os').system('xcalc')"
  MAX_DIST: 0.2
  MIN_CONFIDENCE: 0.3
  NMS_MAX_OVERLAP: 0.5
  MAX_IOU_DISTANCE: 0.7
  MAX_AGE: 70
  N_INIT: 3
  NN_BUDGET: 100
"""
open('deep_sort.yaml','w+').write(exploit)
os.chdir('../')
print(os.listdir('./'))
os.system('python yolov3_deepsort.py demo/demo.avi --config_deepsort configs/deep_sort.yaml')
```


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again, `calc` wont pop and no code will be executed. Hence code exec is mitigated.


### 👍 User Acceptance Testing (UAT)

Only `safe_load` is used, which is the safer function, no breaking changes introduced.